### PR TITLE
Visual cues to invoice type during creation process

### DIFF
--- a/packages/dapp/src/pages/SelectInvoiceType.jsx
+++ b/packages/dapp/src/pages/SelectInvoiceType.jsx
@@ -88,7 +88,7 @@ export const SelectInvoiceType = () => {
           flexDir="column"
           paddingY={6}
         >
-          <Heading>Escrow</Heading>
+          <Heading>🔐 Escrow 🔓</Heading>
           <Box mt={2} textAlign="center" fontSize={12} fontWeight="normal">
             <Text>Secure funds and release payments by milestones.</Text>
             <Text>Includes arbitration.</Text>
@@ -111,7 +111,7 @@ export const SelectInvoiceType = () => {
           flexDir="column"
         >
           <Flex direction="column">
-            <Heading>Instant</Heading>
+            <Heading>⚡ Instant ⚡</Heading>
             <Box mt={2} textAlign="center" fontSize={12} fontWeight="normal">
               <Text wordBreak="break-word">Receive payment immediately.</Text>
               <Text>Does NOT include arbitration.</Text>

--- a/packages/dapp/src/pages/escrow/CreateInvoiceEscrow.jsx
+++ b/packages/dapp/src/pages/escrow/CreateInvoiceEscrow.jsx
@@ -89,7 +89,7 @@ export const CreateInvoiceEscrowInner = () => {
             w={{ base: '100%', md: 'auto' }}
           >
             <Heading fontWeight="700" fontSize={headingSize}>
-              Create an Escrow Invoice
+              🔐 Create an Escrow Invoice 🔓
             </Heading>
             <Text
               color="#90A0B7"

--- a/packages/dapp/src/pages/instant/CreateInvoiceInstant.jsx
+++ b/packages/dapp/src/pages/instant/CreateInvoiceInstant.jsx
@@ -87,7 +87,7 @@ export const CreateInvoiceInstantInner = () => {
             w={{ base: '100%', md: 'auto' }}
           >
             <Heading fontWeight="700" fontSize={headingSize}>
-              Create an Instant Invoice
+              ⚡ Create an Instant Invoice ⚡
             </Heading>
             <Text
               color="#90A0B7"


### PR DESCRIPTION
Added simple icons to visually differentiate the creation flow between escrow and instant:

**Invoice Selection:**
<img width="906" alt="Screen Shot 2023-02-09 at 2 01 08 PM" src="https://user-images.githubusercontent.com/72105234/219459289-efcb4b11-21d7-4823-835b-4068cf2dbf9c.png">

**On Escrow creation:**
<img width="834" alt="Screen Shot 2023-02-09 at 2 01 15 PM" src="https://user-images.githubusercontent.com/72105234/219459350-501430f9-dfd1-4f6f-8384-e868c67f40b3.png">

**On Instant creation:**
<img width="952" alt="Screen Shot 2023-02-09 at 1 58 43 PM" src="https://user-images.githubusercontent.com/72105234/219459392-1c7770da-6816-4bd7-b539-652f8c6a3f39.png">
