### PR TITLE
fix doctype error in SmartInvoiceEscrow.sol

### DIFF
--- a/packages/contracts/contracts/SmartInvoiceEscrow.sol
+++ b/packages/contracts/contracts/SmartInvoiceEscrow.sol
@@ -324,7 +324,7 @@ contract SmartInvoiceEscrow is
     /**
      * @dev External function to release funds from the contract to the provider.
      * Uses the internal `_release` function to perform the actual release.
-     * @param _milestones The milestones to release funds to
+     * @param _token The token address in which funds are to be released.
      */
     function releaseTokens(address _token) external override nonReentrant {
         if (_token == token) {


### PR DESCRIPTION
Smart invoice escrow Doctype fix

Found while compiling in Remix


<img width="1104" alt="Screenshot 2023-08-15 at 5 51 05 PM" src="https://github.com/SmartInvoiceXYZ/smart-invoice/assets/19414083/da597733-a600-4808-b87d-b1873ff48011">
