### PR TITLE
update useEscrowZap inputs

### DIFF
--- a/packages/constants/src/config.ts
+++ b/packages/constants/src/config.ts
@@ -1,5 +1,5 @@
 import { toLower } from 'lodash';
-import { Address, Chain } from 'viem';
+import { Address, Chain, Hex } from 'viem';
 import {
   arbitrum,
   base,
@@ -27,6 +27,13 @@ type ResolverWithoutAddress = {
   termsUrl: string;
 };
 
+type Tokens = {
+  [key: string]: {
+    decimals: number;
+    address: Hex;
+  };
+};
+
 export type Resolver = {
   address: Address;
 } & ResolverWithoutAddress;
@@ -36,6 +43,11 @@ export type NetworkConfig = {
   WRAPPED_NATIVE_TOKEN: Address;
   INVOICE_FACTORY: Address;
   RESOLVERS: Partial<Record<KnownResolverType, Resolver>>;
+  TOKENS?: Tokens;
+  ZAP_ADDRESS?: Hex;
+  DAO_ADDRESS?: Hex;
+  TREASURY_ADDRESS?: Hex;
+  SPOILS_MANAGER?: Hex;
 };
 
 export type KlerosCourtData = {

--- a/packages/hooks/src/types.ts
+++ b/packages/hooks/src/types.ts
@@ -1,8 +1,7 @@
-import { useSimulateContract, useWriteContract } from 'wagmi';
+import {
+  useSimulateContract,
+  useWriteContract,
+} from 'wagmi';
 
-export type SimulateContractErrorType = ReturnType<
-  typeof useSimulateContract
->['error'];
-export type WriteContractErrorType = ReturnType<
-  typeof useWriteContract
->['error'];
+export type SimulateContractErrorType = ReturnType<typeof useSimulateContract>["error"];
+export type WriteContractErrorType = ReturnType<typeof useWriteContract>["error"];

--- a/packages/hooks/src/types.ts
+++ b/packages/hooks/src/types.ts
@@ -1,7 +1,8 @@
-import {
-  useSimulateContract,
-  useWriteContract,
-} from 'wagmi';
+import { useSimulateContract, useWriteContract } from 'wagmi';
 
-export type SimulateContractErrorType = ReturnType<typeof useSimulateContract>["error"];
-export type WriteContractErrorType = ReturnType<typeof useWriteContract>["error"];
+export type SimulateContractErrorType = ReturnType<
+  typeof useSimulateContract
+>['error'];
+export type WriteContractErrorType = ReturnType<
+  typeof useWriteContract
+>['error'];


### PR DESCRIPTION
## Summary
Updated `useEscrowZap.ts` to be compatible with **DM** requirements and kept old values as default values : 
- `networkConfig` is a new input so that **DM** can use their own wagmi configs and `NETWORK_CONFIG` is used as default value
- `detailsData` is a new input and it's defaulted to null if not used.
- Updated the hook to correctly handle token decimals and addresses based on the provided network configuration.
- Modified the `useSimulateContract` call to use the `ZAP_ADDRESS` from the network configuration.
 Adjusted the loading state to include `detailsLoading`.
