### PR TITLE
fix useEscrowZap and useLock

### DIFF
--- a/packages/hooks/src/useEscrowZap.ts
+++ b/packages/hooks/src/useEscrowZap.ts
@@ -1,4 +1,4 @@
-import { ESCROW_ZAP_ABI, NETWORK_CONFIG } from '@smartinvoicexyz/constants';
+import { ESCROW_ZAP_ABI } from '@smartinvoicexyz/constants';
 import { logDebug } from '@smartinvoicexyz/utils';
 import _ from 'lodash';
 import { useCallback, useMemo } from 'react';
@@ -54,24 +54,17 @@ export const useEscrowZap = ({
   const { owners, percentAllocations } =
     separateOwnersAndAllocations(ownersAndAllocations);
   const saltNonce = Math.floor(new Date().getTime() / 1000);
-  const milestoneAmounts = networkConfig?.tokenDecimals
-    ? _.map(
-        milestones,
-        (a: { value: string }) =>
-          a.value && parseUnits(a.value, networkConfig.tokenDecimals),
-      )
-    : _.map(
-        milestones,
-        (a: { value: string }) => a.value && parseEther(a.value),
-      );
+  const milestoneAmounts = _.map(
+    milestones,
+    (a: { value: string }) =>
+      a.value && parseUnits(a.value, networkConfig.tokenDecimals),
+  );
 
-  const tokenAddress = networkConfig?.tokenAddress
-    ? networkConfig?.tokenAddress
-    : '0x0';
+  const { tokenAddress } = networkConfig;
 
   const resolver = daoSplit
-    ? (_.first(_.keys(_.get(NETWORK_CONFIG[chainId], 'RESOLVERS'))) as Hex)
-    : (NETWORK_CONFIG[chainId].DAO_ADDRESS ?? '');
+    ? networkConfig?.resolver
+    : networkConfig.daoAddress;
 
   const encodedSafeData = useMemo(() => {
     if (!threshold || !saltNonce)
@@ -156,7 +149,7 @@ export const useEscrowZap = ({
     status,
   } = useSimulateContract({
     chainId,
-    address: networkConfig?.ZAP_ADDRESS ?? '0x0',
+    address: networkConfig.zapAddress,
     abi: ESCROW_ZAP_ABI,
     functionName: 'createSafeSplitEscrow',
     args: [
@@ -222,10 +215,12 @@ interface UseEscrowZapProps {
   safetyValveDate: Date;
   details?: `0x${string}` | null;
   enabled?: boolean;
-  networkConfig?: {
+  networkConfig: {
     tokenAddress: Hex;
     tokenDecimals: number;
-    ZAP_ADDRESS: Hex;
+    zapAddress: Hex;
+    resolver: Hex;
+    daoAddress: Hex;
   };
   onSuccess?: (hash: Hex) => void;
 }

--- a/packages/hooks/src/useEscrowZap.ts
+++ b/packages/hooks/src/useEscrowZap.ts
@@ -2,13 +2,7 @@ import { ESCROW_ZAP_ABI } from '@smartinvoicexyz/constants';
 import { logDebug } from '@smartinvoicexyz/utils';
 import _ from 'lodash';
 import { useCallback, useMemo } from 'react';
-import {
-  encodeAbiParameters,
-  Hex,
-  isAddress,
-  parseEther,
-  parseUnits,
-} from 'viem';
+import { encodeAbiParameters, Hex, isAddress, parseUnits } from 'viem';
 import { useChainId, useSimulateContract, useWriteContract } from 'wagmi';
 
 import { SimulateContractErrorType, WriteContractErrorType } from './types';
@@ -62,9 +56,7 @@ export const useEscrowZap = ({
 
   const { tokenAddress } = networkConfig;
 
-  const resolver = daoSplit
-    ? networkConfig?.resolver
-    : networkConfig.daoAddress;
+  const resolver = daoSplit ? networkConfig.resolver : networkConfig.daoAddress;
 
   const encodedSafeData = useMemo(() => {
     if (!threshold || !saltNonce)

--- a/packages/hooks/src/useLock.ts
+++ b/packages/hooks/src/useLock.ts
@@ -50,12 +50,15 @@ export const useLock = ({
   isLoading: boolean;
   prepareError: SimulateContractErrorType | null;
   writeError: WriteContractErrorType | null;
+  txHash: Hex | undefined;
 } => {
   const currentChainId = useChainId();
   const { chainId: invoiceChainId, metadata } = _.pick(invoice, [
     'chainId',
     'metadata',
   ]);
+
+  const [txHash, setTxHash] = useState<Hex | undefined>(undefined);
 
   const { description, document } = localForm.getValues();
 
@@ -117,7 +120,7 @@ export const useLock = ({
         if (receipt && publicClient) {
           await waitForSubgraphSync(publicClient.chain.id, receipt.blockNumber);
         }
-
+        setTxHash(hash);
         setWaitingForTx(false);
         onTxSuccess?.();
       },
@@ -146,5 +149,6 @@ export const useLock = ({
       !(details || !detailsLoading),
     prepareError,
     writeError,
+    txHash,
   };
 };

--- a/packages/hooks/src/useLock.ts
+++ b/packages/hooks/src/useLock.ts
@@ -50,15 +50,12 @@ export const useLock = ({
   isLoading: boolean;
   prepareError: SimulateContractErrorType | null;
   writeError: WriteContractErrorType | null;
-  txHash: Hex | undefined;
 } => {
   const currentChainId = useChainId();
   const { chainId: invoiceChainId, metadata } = _.pick(invoice, [
     'chainId',
     'metadata',
   ]);
-
-  const [txHash, setTxHash] = useState<Hex | undefined>(undefined);
 
   const { description, document } = localForm.getValues();
 
@@ -120,7 +117,7 @@ export const useLock = ({
         if (receipt && publicClient) {
           await waitForSubgraphSync(publicClient.chain.id, receipt.blockNumber);
         }
-        setTxHash(hash);
+
         setWaitingForTx(false);
         onTxSuccess?.();
       },
@@ -149,6 +146,5 @@ export const useLock = ({
       !(details || !detailsLoading),
     prepareError,
     writeError,
-    txHash,
   };
 };


### PR DESCRIPTION
## useEscrowZap
- since useEscrowZap is only used in DM, netwrokConfig is now required.
- fix resolver Address

## useLock
- return txHash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Lock actions now return a transaction hash to help track successful operations.
  
- **Refactor**
  - Streamlined network configuration handling to ensure all required connection details are provided without fallback logic.
  - Updated the `networkConfig` interface to require essential properties, enhancing clarity and reducing conditional checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->