### PR TITLE
fix: ensure result is a Date object in sevenDaysFromDate function

### DIFF
--- a/packages/utils/src/date.ts
+++ b/packages/utils/src/date.ts
@@ -53,7 +53,7 @@ export const oneMonthFromNow = () => {
 };
 
 export const sevenDaysFromDate = (date: DateInput) => {
-  const result = parseToDate(date);
+  const result = new Date(parseToDate(date));
   result.setDate(result.getDate() + 7);
   return result;
 };


### PR DESCRIPTION
fixes #310


## Root Cause
sevenDaysFromDate mutates the date object in place
that causes the end date to be modified by 7 days while adding 7 days to the deadline.
## Fix
Ensure sevenDaysFromDate returns a new Date object and does not mutate the input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved date calculation reliability to prevent potential issues when adding 7 days to a given date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->